### PR TITLE
docs: Fix example for __definitions__

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ foo: true
 
 ```yaml
   # the special keyword __definitions__ allows to define custom statements
-  __imports__:
+  __definitions__:
     - from itertools import product
     - |
       def squared(value):


### PR DESCRIPTION
This PR fixes the example for custom statements in the README.md. 