### PR TITLE
fix: improved error message in case of YAML syntax errors

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -163,4 +163,3 @@ def test_colon_unquoted():
               ?f"{sample}: observations": 1
             """
         )
-        assert result == {"normal: observations": 1, "tumor: observations": 1}

--- a/tests.py
+++ b/tests.py
@@ -148,7 +148,7 @@ def test_colon():
     result = _process(
         """
         ?for sample in ["normal", "tumor"]:
-          ?f"{sample}: observations": 1
+          '?f"{sample}: observations"': 1
         """
     )
     assert result == {"normal: observations": 1, "tumor: observations": 1}

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 import yte
 import textwrap
 import pytest
+import yaml
 import subprocess as sp
 
 
@@ -152,3 +153,14 @@ def test_colon():
         """
     )
     assert result == {"normal: observations": 1, "tumor: observations": 1}
+
+
+def test_colon_unquoted():
+    with pytest.raises(yaml.scanner.ScannerError):
+        result = _process(
+            """
+            ?for sample in ["normal", "tumor"]:
+              ?f"{sample}: observations": 1
+            """
+        )
+        assert result == {"normal: observations": 1, "tumor: observations": 1}

--- a/tests.py
+++ b/tests.py
@@ -157,7 +157,7 @@ def test_colon():
 
 def test_colon_unquoted():
     with pytest.raises(yaml.scanner.ScannerError):
-        result = _process(
+        _process(
             """
             ?for sample in ["normal", "tumor"]:
               ?f"{sample}: observations": 1

--- a/tests.py
+++ b/tests.py
@@ -142,3 +142,13 @@ def test_func_definition():
 
 def test_cli():
     sp.check_call("echo -e '?if True:\n  foo: 1' | yte", shell=True)
+
+
+def test_colon():
+    result = _process(
+        """
+        ?for sample in ["normal", "tumor"]:
+          ?f"{sample}: observations": 1
+        """
+    )
+    assert result == {"normal: observations": 1, "tumor: observations": 1}

--- a/yte/__init__.py
+++ b/yte/__init__.py
@@ -11,9 +11,17 @@ def process_yaml(file_or_str, outfile=None, variables=None):
     if variables is None:
         variables = dict()
     variables["_process_yaml_value"] = _process_yaml_value
-    result = _process_yaml_value(
-        yaml.load(file_or_str, Loader=yaml.FullLoader), variables
-    )
+
+    try:
+        yaml_doc = yaml.load(file_or_str, Loader=yaml.FullLoader)
+    except yaml.scanner.ScannerError as e:
+        raise yaml.scanner.ScannerError(
+            f"{e}\nNote that certain characters like colons have a special "
+            "meaning in YAML and hence keys or values containing them have "
+            "to be quoted."
+        )
+
+    result = _process_yaml_value(yaml_doc, variables)
 
     if outfile is not None:
         yaml.dump(result, outfile)


### PR DESCRIPTION
Currently yte fails parsing when a colon is part of a format string.