### PR TITLE
fix: do not sort keys upon output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 authors = ["Johannes Köster <johannes.koester@tu-dortmund.de>"]
 description = "A YAML template engine with Python expressions"
-readme = "README.md"
 homepage = "https://github.com/koesterlab/yte"
-repository = "https://github.com/koesterlab/yte"
 license = "MIT"
 name = "yte"
+readme = "README.md"
+repository = "https://github.com/koesterlab/yte"
 version = "1.2.2"
 
 [tool.poetry.dependencies]
@@ -14,8 +14,8 @@ python = ">=3.7"
 pyyaml = "^6.0"
 
 [tool.poetry.dev-dependencies]
-coverage = {extras = ["toml"], version = "^6.3.1"}
 black = "^22.1.0"
+coverage = {extras = ["toml"], version = "^6.3.1"}
 flake8 = "^4.0.1"
 flake8-bugbear = "^22.1.11"
 pytest = "^7.0"

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import tempfile
 import yte
 import textwrap
 import pytest
@@ -5,8 +6,8 @@ import yaml
 import subprocess as sp
 
 
-def _process(yaml_str):
-    return yte.process_yaml(textwrap.dedent(yaml_str))
+def _process(yaml_str, outfile=None):
+    return yte.process_yaml(textwrap.dedent(yaml_str), outfile=outfile)
 
 
 def test_ifelse():
@@ -210,4 +211,14 @@ def test_colon_unquoted():
             ?for sample in ["normal", "tumor"]:
               ?f"{sample}: observations": 1
             """
+        )
+
+
+def test_outfile():
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        _process(
+            """
+            foo
+            """,
+            outfile=tmp,
         )

--- a/yte/__init__.py
+++ b/yte/__init__.py
@@ -24,7 +24,7 @@ def process_yaml(file_or_str, outfile=None, variables=None):
     result = _process_yaml_value(yaml_doc, variables)
 
     if outfile is not None:
-        yaml.dump(result, outfile)
+        yaml.dump(result, outfile, sort_keys=False)
     else:
         return result
 


### PR DESCRIPTION
Instead, keep the YAML in the original order