### PR TITLE
feat: variable definitions as an alternative to full Python definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,25 @@ foo: 1
 foo: true
 ```
 
-#### Custom definitions
+#### Variable definitions
+
+##### Template
+
+```yaml
+__variables__:
+  someval: "foo"
+  someother: 1.5
+
+key: ?someother
+```
+
+##### Rendered
+
+```yaml
+key: 1.5
+```
+
+#### Arbitrary definitions
 
 ##### Template
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ foo: true
 __variables__:
   first: foo
   second: 1.5
-  third: ?2 * 3
+  # apart from constant values as defined above, also Python expressions are allowed:
+  third: ?2 * 3 
 
 
 a: ?first

--- a/README.md
+++ b/README.md
@@ -98,11 +98,25 @@ foo: true
 ##### Template
 
 ```yaml
-__variables__:
-  someval: "foo"
-  someother: 1.5
+# The special keyword __variables__ allows to define variables that can be reused below.
+# It can be used anywhere in the YAML, also repeatedly and inside of ifs or loops
+# with the restriction of not having duplicate __variables__ keys on the same level.
 
-key: ?someother
+# The usage of __variables__ can be disabled via the API.
+
+__variables__:
+  first: foo
+  second: 1.5
+  third: ?2 * 3
+
+
+a: ?first
+b: ?second
+c:
+  ?for x in range(3):
+    __variables__:
+      y: ?x * 2
+    - ?y
 ```
 
 ##### Rendered
@@ -119,6 +133,9 @@ key: 1.5
   # The special keyword __definitions__ allows to define custom statements.
   # It can be used anywhere in the YAML, also repeatedly and inside of ifs or loops
   # with the restriction of not having duplicate __definitions__ keys on the same level.
+
+  # The usage of __definitions__ can be disabled via the API.
+
   __definitions__:
     - from itertools import product
     - someval = 2
@@ -178,6 +195,19 @@ with open("the-template.yaml", "r") as template:
 # render a file and write the result as valid YAML
 with open("the-template.yaml", "r") as template, open("the-rendered-version.yaml", "w") as outfile:
     result = process_yaml(template, outfile=outfile, variables=variables)
+
+
+# render a file while disabling the __definitions__ feature
+with open("the-template.yaml", "r") as template:
+    result = process_yaml(template, variables=variables, disable_features=["definitions"])
+
+# render a file while disabling the __variables__ feature
+with open("the-template.yaml", "r") as template:
+    result = process_yaml(template, variables=variables, disable_features=["variables"])
+
+# render a file while disabling the __variables__ and __definitions__ feature
+with open("the-template.yaml", "r") as template:
+    result = process_yaml(template, variables=variables, disable_features=["variables", "definitions"])
 ```
 
 ## Comparison with other engines

--- a/tests.py
+++ b/tests.py
@@ -252,7 +252,7 @@ def test_variables():
         __variables__:
           foo: "x"
           bar: 3
-        
+
         ?foo: 1
         bar: ?bar
         """

--- a/yte/__init__.py
+++ b/yte/__init__.py
@@ -12,7 +12,8 @@ def process_yaml(file_or_str, outfile=None, variables=None, disable_features=Non
     * file_or_str - file object or string to render
     * outfile - output file to write to, if None output is returned as string
     * variables - variables to be available in the template
-    * disable_features - list of features that should be disabled during rendering. Possible values to choose from are ["definitions", "variables"]
+    * disable_features - list of features that should be disabled during rendering.
+      Possible values to choose from are ["definitions", "variables"]
     """
     if variables is None:
         variables = dict()

--- a/yte/__init__.py
+++ b/yte/__init__.py
@@ -27,7 +27,14 @@ def process_yaml(file_or_str, outfile=None, variables=None, disable_features=Non
             "to be quoted."
         )
 
-    result = _process_yaml_value(yaml_doc, variables, context=[])
+    if disable_features is not None:
+        disable_features = frozenset(disable_features)
+    else:
+        disable_features = frozenset([])
+
+    result = _process_yaml_value(
+        yaml_doc, variables, context=[], disable_features=disable_features
+    )
 
     if outfile is not None:
         yaml.dump(result, outfile)

--- a/yte/__init__.py
+++ b/yte/__init__.py
@@ -4,9 +4,15 @@ import plac
 from yte.utils import _process_yaml_value
 
 
-def process_yaml(file_or_str, outfile=None, variables=None):
+def process_yaml(file_or_str, outfile=None, variables=None, disable_features=None):
     """Process a YAML file or string with YTE,
     returning the processed version.
+
+    # Arguments
+    * file_or_str - file object or string to render
+    * outfile - output file to write to, if None output is returned as string
+    * variables - variables to be available in the template
+    * disable_features - list of features that should be disabled during rendering. Possible values to choose from are ["definitions", "variables"]
     """
     if variables is None:
         variables = dict()

--- a/yte/utils.py
+++ b/yte/utils.py
@@ -46,6 +46,8 @@ def _process_dict_items(yaml_value, variables):
     for key, value in yaml_value.items():
         if key == "__definitions__":
             _process_definitions(value, variables)
+        elif key == "__variables__":
+            _process_variables(value, variables)
         elif re_for_loop.match(key):
             yield from _process_for_loop(key, value, variables, conditional)
         elif re_if.match(key):
@@ -70,6 +72,16 @@ def _process_definitions(value, variables):
             exec(item, variables)
     else:
         raise ValueError("__definitions__ keyword expects a list of Python statements")
+
+
+def _process_variables(value, variables):
+    if isinstance(value, dict):
+        for name, expr in value.items():
+            variables["name"] = eval(expr, variables)
+    else:
+        raise YteError(
+            "__variables__ keyword expects a map of variable names and values"
+        )
 
 
 def _process_for_loop(key, value, variables, conditional):

--- a/yte/utils.py
+++ b/yte/utils.py
@@ -108,10 +108,10 @@ def _process_definitions(value, variables, context: list):
 
 def _process_variables(value, variables, context: list):
     if isinstance(value, dict):
-        for name, value in value.items():
-            if _is_expr(value):
-                value = _process_expr(value, variables, context)
-            variables[name] = value
+        for name, val in value.items():
+            if _is_expr(val):
+                val = _process_expr(val, variables, context)
+            variables[name] = val
     else:
         raise YteError(
             "__variables__ keyword expects a map of variable names and values", context
@@ -128,7 +128,8 @@ def _process_for_loop(
     _variables["_disable_features"] = disable_features
     _variables["_yte_variables"] = _variables
     yield from eval(
-        f"[_process_yaml_value(_yte_value, dict(_yte_variables, **locals()), _context, _disable_features) "
+        f"[_process_yaml_value(_yte_value, dict(_yte_variables, **locals()), "
+        "_context, _disable_features) "
         f"{key[1:]}]",
         _variables,
     )
@@ -184,11 +185,15 @@ class Conditional:
     def conditional_expr(self, index=0):
         if index < len(self.exprs):
             return (
-                f"_process_yaml_value({self.value_name(index)}, _yte_variables, _context, _disable_features) "
+                f"_process_yaml_value({self.value_name(index)}, "
+                "_yte_variables, _context, _disable_features) "
                 f"if {self.exprs[index]} else {self.conditional_expr(index + 1)}"
             )
         if index < len(self.values):
-            return f"_process_yaml_value({self.value_name(index)}, _yte_variables, _context, _disable_features)"
+            return (
+                f"_process_yaml_value({self.value_name(index)}, "
+                "_yte_variables, _context, _disable_features)"
+            )
         else:
             return "None"
 


### PR DESCRIPTION
fixes #12

Both variables, and full definitions can now be deactivated via the API, yielding an error if they are still used in the document