### PR TITLE
build: Add project.license-files to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ authors = [
 ]
 description = "A YAML template engine with Python expressions"
 license = "MIT"
+license-files = ["LICENSE"]
 name = "yte"
 readme = "README.md"
 version = "1.9.0"


### PR DESCRIPTION
This ensures that the license text in `LICENSE` is included in wheels (inside the `.dist-info` directory), as required by the chosen MIT license, and that `LICENSE` is recorded as a `License-File` in the package metadata.

See:

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files