### PR TITLE
docs: Fix variable 'c' to 'd' in dpath example

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -144,7 +144,7 @@ bar:
   a: 2
   b: 3
   c: 2
-  c: 3
+  d: 3
 ```
 
 ### Variable definitions


### PR DESCRIPTION
This pull request makes a small update to the `docs/main.md` file, correcting a variable label in a code example.